### PR TITLE
Add access to optional parameter to register_spawn

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -906,7 +906,7 @@ function mob_core.register_spawn(def, interval, chance)
 					def.min_rad or 24,
 					def.max_rad or 256,
 					def.group or 1,
-                                        def.optional or nil
+					def.optional or nil
 				)
 			end
 			spawn_timer = 0

--- a/api.lua
+++ b/api.lua
@@ -905,7 +905,8 @@ function mob_core.register_spawn(def, interval, chance)
 					def.max_height or 31000,
 					def.min_rad or 24,
 					def.max_rad or 256,
-					def.group or 1
+					def.group or 1,
+                                        def.optional or nil
 				)
 			end
 			spawn_timer = 0


### PR DESCRIPTION
Adjusts `mob_core.register_spawn` to add option to pass along `optional` parameter to `mob_core.spawn`. If this is added, my PR on paleotest can be simplified to use `mob_core.register_spawn`.