### PR TITLE
Fix spawning and settings crash

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -937,9 +937,9 @@ function mob_core.spawn(name, nodes, min_light, max_light, min_height,
             end
             --return mob_spawned, spawned_pos
 			--moved the execution of registered_on_spawns here
-			if mob_spawned == true and mob_core.registered_on_spawns[def.name] then
-				mob_core.registered_spawns[def.name].last_pos = spawned_pos
-				local on_spawn = mob_core.registered_on_spawns[def.name]
+			if mob_spawned == true and mob_core.registered_on_spawns[name] then
+				mob_core.registered_spawns[name].last_pos = spawned_pos
+				local on_spawn = mob_core.registered_on_spawns[name]
 				on_spawn.func(unpack(on_spawn.args))
 			end
         end

--- a/api.lua
+++ b/api.lua
@@ -805,7 +805,7 @@ end
 local find_node_height = 32
 
 local block_protected_spawn = minetest.settings:get_bool("block_protected_spawn") or true
-local mob_limit = minetest.settings:get("mob_limit") or 6
+local mob_limit = tonumber(minetest.settings:get("mob_limit") or 6)
 
 function mob_core.spawn(name, nodes, min_light, max_light, min_height,
                         max_height, min_rad, max_rad, group, optional)

--- a/api.lua
+++ b/api.lua
@@ -931,18 +931,17 @@ function mob_core.spawn(name, nodes, min_light, max_light, min_height,
 								attempts = attempts + 1
 							end
 						end
-					end
-
-					--moved the execution of registered_on_spawns here
-					if mob_spawned == true and mob_core.registered_on_spawns[def.name] then
-                        mob_core.registered_spawns[def.name].last_pos = last_pos
-                        local on_spawn = mob_core.registered_on_spawns[def.name]
-                        on_spawn.func(unpack(on_spawn.args))
-                    end
+					end					
                     break
                 end
             end
             --return mob_spawned, spawned_pos
+			--moved the execution of registered_on_spawns here
+			if mob_spawned == true and mob_core.registered_on_spawns[def.name] then
+				mob_core.registered_spawns[def.name].last_pos = spawned_pos
+				local on_spawn = mob_core.registered_on_spawns[def.name]
+				on_spawn.func(unpack(on_spawn.args))
+			end
         end
     end
 end
@@ -970,6 +969,7 @@ function mob_core.register_spawn(def, interval, chance)
                             def.group or 1,
                             def.optional or nil
                         )
+						-- moved into mob_core.spawn()
                     -- if spawned and mob_core.registered_on_spawns[def.name] then
                     --     mob_core.registered_spawns[def.name].last_pos = last_pos
                     --     local on_spawn = mob_core.registered_on_spawns[def.name]

--- a/api.lua
+++ b/api.lua
@@ -797,90 +797,148 @@ minetest.register_chatcommand("force_tame", {
 
 -- Spawning --
 
+function mob_core.get_biome_name(pos)
+	if not pos then return end
+	return minetest.get_biome_name(minetest.get_biome_data(pos).biome)
+end
+
 local find_node_height = 32
 
 local block_protected_spawn = minetest.settings:get_bool("block_protected_spawn") or true
-local mob_limit = minetest.settings:get_bool("mob_limit") or 6
+local mob_limit = minetest.settings:get("mob_limit") or 6
 
-function mob_core.spawn(name, nodes, min_light, max_light, min_height, max_height, min_rad, max_rad, group)
-	if minetest.registered_entities[name] then
-		for _,player in ipairs(minetest.get_connected_players()) do
-			local spawn_mob = true
-			local mobs_amount = 0
+function mob_core.spawn(name, nodes, min_light, max_light, min_height,
+                        max_height, min_rad, max_rad, group, optional)
+    group = group or 1
+    if minetest.registered_entities[name] then
+        for _, player in ipairs(minetest.get_connected_players()) do
+            local mobs_amount = 0
+			--use this instead of 'return'
+			local allow_spawn_mob = true
 
-			for _, entity in pairs(minetest.luaentities) do
-				if entity.name == name then
-					local ent_pos = entity.object:get_pos()
-					if ent_pos and vector.distance(player:get_pos(), ent_pos) <= max_rad then
-						mobs_amount = mobs_amount + 1
+
+            for _, entity in pairs(minetest.luaentities) do
+                if entity.name == name then
+                    local ent_pos = entity.object:get_pos()
+                    if ent_pos and vector.distance(player:get_pos(), ent_pos) <=
+                        max_rad then
+                        mobs_amount = mobs_amount + 1
+                    end
+                end
+            end
+
+            local mob_spawned = false
+
+            local spawned_pos = nil
+
+            if mobs_amount >= mob_limit then allow_spawn_mob = false end
+
+            local reliability = 3
+
+            if optional and optional.reliability then
+                reliability = optional.reliability
+            end
+
+            for _ = 1, reliability do -- 3 attempts
+                local int = {-1, 1}
+                local pos = vector.floor(vector.add(player:get_pos(), 0.5))
+
+                local x, z
+
+                -- this is used to determine the axis buffer from the player
+                local axis = math.random(0, 1)
+
+                -- cast towards the direction
+                if axis == 0 then -- x
+                    x = pos.x + math.random(min_rad, max_rad) *
+                            int[random(1, 2)]
+                    z = pos.z + math.random(-max_rad, max_rad)
+                else -- z
+                    z = pos.z + math.random(min_rad, max_rad) *
+                            int[random(1, 2)]
+                    x = pos.x + math.random(-max_rad, max_rad)
+                end
+
+                local spawner = minetest.find_nodes_in_area_under_air(
+                                    vector.new(x - 1, pos.y - find_node_height,
+                                               z - 1), vector.new(x + 1,
+                                                                  pos.y +
+                                                                      find_node_height,
+                                                                  z + 1), nodes)
+
+                if table.getn(spawner) > 0 then
+                    local mob_pos = spawner[1]
+
+                    if block_protected_spawn and
+                        minetest.is_protected(mob_pos, "") then
+							allow_spawn_mob = false
+                    end
+
+                    if optional then
+                        if optional.biomes then
+                            if not mob_core.find_val(optional.biomes,
+                                                     mob_core.get_biome_name(pos)) then
+														allow_spawn_mob = false
+                            end
+                        end
+                    end
+
+                    if mob_pos.y > max_height or mob_pos.y < min_height then
+                        allow_spawn_mob = false
+                    end
+
+                    local light = minetest.get_node_light(mob_pos)
+                    if not light or light > max_light or light < min_light then
+                        allow_spawn_mob = false
+                    end
+
+
+					if allow_spawn_mob == true then
+						mob_spawned = true
+
+						spawned_pos = mob_pos
+
+						minetest.add_entity(mob_pos, name)
+
+						if group then
+
+							local spawned = 0
+
+							local attempts = 0
+
+							while spawned < group and attempts < group * 2 do
+								local mobdef = minetest.registered_entities[name]
+								local side = mobdef.collisionbox[4]
+								local group_pos =
+									vector.new(
+										mob_pos.x + (random(-group, group) * side),
+										mob_pos.y,
+										mob_pos.z + (random(-group, group) * side))
+								local spawn_pos =
+									minetest.find_nodes_in_area_under_air(
+										vector.new(group_pos.x, group_pos.y - 8,
+												group_pos.z), vector.new(
+											group_pos.x, group_pos.y + 8,
+											group_pos.z), nodes)
+								if spawn_pos[1] then
+									minetest.add_entity(
+										vector.new(spawn_pos[1].x, spawn_pos[1].y +
+													math.abs(
+														mobdef.collisionbox[2]),
+												spawn_pos[1].z), name)
+									spawned = spawned + 1
+								end
+								attempts = attempts + 1
+							end
+						end
 					end
-				end
-			end
-
-			if mobs_amount >= mob_limit then
-				spawn_mob = false
-			end
-
-			local int = {-1,1}
-			local pos = vector.floor(vector.add(player:get_pos(),0.5))
-
-			local x,z
-
-			--this is used to determine the axis buffer from the player
-			local axis = math.random(0,1)
-
-			--cast towards the direction
-			if axis == 0 then --x
-				x = pos.x + math.random(min_rad,max_rad)*int[math.random(1,2)]
-				z = pos.z + math.random(-max_rad,max_rad)
-			else --z
-				z = pos.z + math.random(min_rad,max_rad)*int[math.random(1,2)]
-				x = pos.x + math.random(-max_rad,max_rad)
-			end
-
-			local spawner = minetest.find_nodes_in_area_under_air(
-				vector.new(x,pos.y-find_node_height,z),
-				vector.new(x,pos.y+find_node_height,z), nodes)
-
-			if table.getn(spawner) > 0 then
-				local mob_pos = spawner[1]
-
-				if block_protected_spawn and minetest.is_protected(mob_pos, "") then
-					spawn_mob = false
-				end
-
-				if mob_pos.y > max_height
-				or mob_pos.y < min_height then
-					spawn_mob = false
-				end
-
-				local light = minetest.get_node_light(mob_pos)
-				if not light
-				or light > max_light
-				or light < min_light then
-					spawn_mob = false
-				end
-
-				if spawn_mob then
-
-					for i = 1, group do
-						local mobdef = minetest.registered_entities[name]
-						local col4 = mobdef.collisionbox[4]
-						local group_pos = minetest.find_nodes_in_area_under_air(
-							{x=mob_pos.x-group-col4,y=mob_pos.y-group,z=mob_pos.z-group-col4},
-							{x=mob_pos.x+group+col4,y=mob_pos.y+group,z=mob_pos.z+group+col4},
-							nodes
-						)
-						if #group_pos < group then group = group-1 end
-						group_pos[i].y = group_pos[i].y + math.abs(mobdef.collisionbox[2])
-						minetest.add_entity(group_pos[i], name)
-					end
-				end
-			end
-		end
-	end
+                    break
+                end
+            end
+            return mob_spawned, spawned_pos
+        end
+    end
 end
-
 
 mob_core.registered_on_spawns = {}
 

--- a/api.lua
+++ b/api.lua
@@ -932,10 +932,17 @@ function mob_core.spawn(name, nodes, min_light, max_light, min_height,
 							end
 						end
 					end
+
+					--moved the execution of registered_on_spawns here
+					if mob_spawned == true and mob_core.registered_on_spawns[def.name] then
+                        mob_core.registered_spawns[def.name].last_pos = last_pos
+                        local on_spawn = mob_core.registered_on_spawns[def.name]
+                        on_spawn.func(unpack(on_spawn.args))
+                    end
                     break
                 end
             end
-            return mob_spawned, spawned_pos
+            --return mob_spawned, spawned_pos
         end
     end
 end
@@ -952,7 +959,7 @@ function mob_core.register_spawn(def, interval, chance)
             spawn_timer = spawn_timer + dtime
             if spawn_timer > interval then
                 if random(1, chance) == 1 then
-                    local spawned, last_pos =
+                    -- local spawned, last_pos =
                         mob_core.spawn(
                             def.name,
                             def.nodes or {"group:soil", "group:stone"},
@@ -963,11 +970,11 @@ function mob_core.register_spawn(def, interval, chance)
                             def.group or 1,
                             def.optional or nil
                         )
-                    if spawned and mob_core.registered_on_spawns[def.name] then
-                        mob_core.registered_spawns[def.name].last_pos = last_pos
-                        local on_spawn = mob_core.registered_on_spawns[def.name]
-                        on_spawn.func(unpack(on_spawn.args))
-                    end
+                    -- if spawned and mob_core.registered_on_spawns[def.name] then
+                    --     mob_core.registered_spawns[def.name].last_pos = last_pos
+                    --     local on_spawn = mob_core.registered_on_spawns[def.name]
+                    --     on_spawn.func(unpack(on_spawn.args))
+                    -- end
                 end
                 spawn_timer = 0
             end


### PR DESCRIPTION
There were 2 problems when we tried to use mob_core on a multiplayer server
 the first was that only the first player to log on would get any mobs spawning around them

this was because the spawn function would "return" if it found unfavorable conditions. THat meant that it never finished iterating over other players.

This PR fixes that issue by implementing a variable "allow_spawn_mob = true/false" and replacing all the placeswhere the function used to return with `allow_spawn_mob = false`. then, it will not spawn the mob or set `mob_spawned` to true if allow_spawn_mob == false

THe other issue is that get_bool was called on a float setting