### PR TITLE
Fix mobkit.turn2yaw override

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1852,8 +1852,8 @@ end
 local old_turn2yaw = mobkit.turn2yaw
 
 function mobkit.turn2yaw(self, tyaw, rate)
-    old_turn2yaw(self, tyaw, rate)
     self._tyaw = tyaw
+    return old_turn2yaw(self, tyaw, rate)
 end
 
 -- Force Tame Command --


### PR DESCRIPTION
This is a partial fix for #15 , and a pretty severe bug as it incorrectly overrides a mobkit method!

Restores some - but not all of the existing behavior in Paleotest. (most mobs move around again. The t-rex still does not move or follow the player)
